### PR TITLE
support for recording number in loading and packing continuous data

### DIFF
--- a/OpenEphys.py
+++ b/OpenEphys.py
@@ -73,8 +73,9 @@ def loadFolder(folderpath,**kwargs):
             
     return data
 
-def loadFolderToArray(folderpath, channels = 'all', dtype = float, 
-    source = '100', recording=None):
+def loadFolderToArray(folderpath, channels='all', dtype=float, 
+    source='100', recording=None, start_record=None, stop_record=None,
+    verbose=True):
     '''Load CH continuous files in specified folder to a single numpy array. By default all 
     CH continous files are loaded in numerical order, ordering can be specified with
     optional channels argument which should be a list of channel numbers.
@@ -83,133 +84,188 @@ def loadFolderToArray(folderpath, channels = 'all', dtype = float,
         Multiple recordings in the same folder are suffixed with an
         incrementing label. For the first or only recording, leave this as
         None. Otherwise, specify an integer.
+    
+    start_record, stop_record : the first and last record to read from
+        each file. This is converted into an appropriate number of samples
+        and passed to loadContinuous. Python indexing is used, so stop_record
+        is not inclusive. If start_record is None, start at the beginning;
+        if stop_record is None, read to the end.
+    
+    verbose : print debugging information
     '''
+    # Get list of files
+    filelist = get_filelist(folderpath, source, channels, recording=None)
 
-    if channels == 'all': 
-        channels = _get_sorted_channels(folderpath, recording=recording)
-
-    # Get the list of continuous filenames
-    if recording is None:
-        filelist = [source + '_CH' + x + '.continuous' for x in map(str,channels)]
-    else:
-        if recording == 1:
-            # The first recording has no suffix
-            filelist = ['%s_CH%d.continuous' % (source, chan)
-                for chan in channels]
-        else:
-            filelist = ['%s_CH%d_%d.continuous' % (source, chan, recording)
-                for chan in channels]
-
+    # Keep track of the time taken
     t0 = time.time()
-    numFiles = 1
 
-    channel_1_data = loadContinuous(os.path.join(folderpath, filelist[0]), dtype)['data']
+    # Get the header info and use this to set start_record and stop_record
+    header = get_header_from_folder(folderpath, filelist)
+    if start_record is None:
+        start_record = 0
+    if stop_record is None:
+        stop_record = header['n_records']
 
-    n_samples  = len(channel_1_data)
-    n_channels = len(filelist)
+    # Extract each channel in order
+    arr_l = []
+    for filename in filelist:
+        arr = loadContinuous(os.path.join(folderpath, filename), dtype,
+            start_record=start_record, stop_record=stop_record, 
+            verbose=verbose)['data']
+        arr_l.append(arr)
+    
+    # Concatenate into an array of shape (n_samples, n_channels)
+    data_array = np.transpose(arr_l)
+    
+    if verbose:
+        time_taken = time.time() - t0
+        print 'Avg. Load Time: %0.3f sec' % (time_taken / len(filelist))
+        print 'Total Load Time: %0.3f sec' % time_taken
 
-    data_array = np.zeros([n_samples, n_channels], dtype)
-    data_array[:,0] = channel_1_data
-
-    for i, f in enumerate(filelist[1:]):
-            data_array[:, i + 1] = loadContinuous(os.path.join(folderpath, f), dtype)['data']
-            numFiles += 1
-
-    print ''.join(('Avg. Load Time: ', str((time.time() - t0)/numFiles),' sec'))
-    print ''.join(('Total Load Time: ', str((time.time() - t0)),' sec'))        
-            
     return data_array
 
-def loadContinuous(filepath, dtype = float):
 
-    assert dtype in (float, np.int16), \
-      'Invalid data type specified for loadContinous, valid types are float and np.int16'
+def loadContinuous(filepath, dtype=float, verbose=True, 
+    start_record=None, stop_record=None, ignore_last_record=True):
+    """Load continuous data from a single channel in the file `filepath`.
+    
+    This is intended to be mostly compatible with the previous version.
+    The differences are:
+    - Ability to specify start and stop records
+    - Converts numeric data in the header from string to numeric data types
+    - Does not rely on a predefined maximum data size
+    - Does not necessarily drop the last record, which is usually incomplete
+    - Uses the block length that is specified in the header, instead of
+        hardcoding it.
+    - Returns timestamps and recordNumbers as int instead of float
+    - Tests the record metadata (N and record marker) for internal consistency
 
-    print "Loading continuous data from " + filepath
+    The OpenEphys file format breaks the data stream into "records", 
+    typically of length 1024 samples. There is only one timestamp per record.
 
-    ch = { }
-    recordNumber = np.intp(-1)
-    
-#    f = open(filepath,'rb')
-#    header = readHeader(f)
-    
-    ##preallocate the data array
-#    while f.tell() < os.fstat(f.fileno()).st_size:
-#        newSampleNumber = np.fromfile(f,np.dtype('<i8'),1)
-#        N = np.fromfile(f,np.dtype('<u2'),1);        
-#        recordingNumber = np.fromfile(f,np.dtype('>u2'),1) 
-#        data = np.fromfile(f,np.dtype('>i2'),N)
-#        marker = f.read(10)
-#        totalN = totalN+1
-        
-#    f.close
-    # pre-allocate samples
-    
-    # Data is loaded in records of size 1024 samples, one timestamp per record
-    
-    # This is where the data will go
-    samples = np.zeros(MAX_NUMBER_OF_CONTINUOUS_SAMPLES, dtype)
-    
-    # This is where the timestamps will go
-    timestamps = np.zeros(MAX_NUMBER_OF_RECORDS)
-    
-    # This might be the recording number?
-    recordingNumbers = np.zeros(MAX_NUMBER_OF_RECORDS)
-    
-    # This is used to figure out how to assign into the predetermined `samples`
-    # array.
-    indices = np.arange(0,MAX_NUMBER_OF_RECORDS*SAMPLES_PER_RECORD, SAMPLES_PER_RECORD, np.dtype(np.int64))
-    
-    #read in the data
-    f = open(filepath,'rb')
-    
-    header = readHeader(f)
-    
-    fileLength = os.fstat(f.fileno()).st_size
-    #print fileLength
-    #print f.tell()
-    
-    while f.tell() < fileLength:
-        # Increment the record count
-        recordNumber += 1        
-        
-        # Read timestamp for this record
-        timestamps[recordNumber] = np.fromfile(f,np.dtype('<i8'),1) # little-endian 64-bit signed integer 
-        
-        # Read the number of samples in this record
-        N = np.fromfile(f,np.dtype('<u2'),1) # little-endian 16-bit unsigned integer
-        
-        #print index
+    Args:
+        filepath : string, path to file to load
+        dtype : float or np.int16
+            If float, then the data will be multiplied by bitVolts to convert
+            to microvolts. This increases the memory required by 4 times.
+        verbose : whether to print debugging messages
+        start_record, stop_record : indices that control how much data
+            is read and returned. Pythonic indexing is used,
+            so `stop_record` is not inclusive. If `start` is None, reading
+            begins at the beginning; if `stop` is None, reading continues
+            until the end.
+        ignore_last_record : The last record in the file is almost always
+            incomplete (padded with zeros). By default it is ignored, for
+            compatibility with the old version of this function.
 
-        if N != SAMPLES_PER_RECORD:
-            raise Exception('Found corrupted record in block ' + str(recordNumber))
+    Returns: dict, with following keys
+        data : array of samples of data
+        header : the header info, as returned by readHeader
+        timestamps : the timestamps of each record of data that was read
+        recordingNumber : the recording number of each record of data that
+            was read. The length is the same as `timestamps`.
+    """
+    if dtype not in [float, np.int16]:
+        raise ValueError("Invalid data type. Must be float or np.int16")
+
+    if verbose:
+        print "Loading continuous data from " + filepath
+
+    """Here is the OpenEphys file format:
+    'each record contains one 64-bit timestamp, one 16-bit sample 
+    count (N), 1 uint16 recordingNumber, N 16-bit samples, and 
+    one 10-byte record marker (0 1 2 3 4 5 6 7 8 255)'
+    Thus each record has size 2*N + 22 bytes.
+    """
+    # This is what the record marker should look like
+    spec_record_marker = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 255])
+
+    # Lists for data that's read
+    timestamps = []
+    recordingNumbers = []
+    samples = []
+    samples_read = 0
+    records_read = 0
+    
+    # Open the file
+    with file(filepath, 'rb') as f:
+        # Read header info, file length, and number of records
+        header = readHeader(f)
+        record_length_bytes = 2 * header['blockLength'] + 22
+        fileLength = os.fstat(f.fileno()).st_size
+        n_records = get_number_of_records(filepath)
         
-        # Read and store the recording numbers
-        recordingNumbers[recordNumber] = (np.fromfile(f,np.dtype('>u2'),1)) # big-endian 16-bit unsigned integer
+        # Use this to set start and stop records if not specified
+        if start_record is None:
+            start_record = 0
+        if stop_record is None:
+            stop_record = n_records
         
-        # Convert the dtype
-        if dtype == float: # Convert data to float array and convert bits to voltage.
-            data = np.fromfile(f,np.dtype('>i2'),N) * float(header['bitVolts']) # big-endian 16-bit signed integer, multiplied by bitVolts   
-        else:  # Keep data in signed 16 bit integer format.
-            data = np.fromfile(f,np.dtype('>i2'),N)  # big-endian 16-bit signed integer
-        try:
-            # Assign data into samples, using indices
-            samples[indices[recordNumber]:indices[recordNumber+1]] = data            
-        except ValueError:
-            print type(index)
-            raise
+        # We'll stop reading after this many records are read
+        n_records_to_read = stop_record - start_record
         
-        marker = f.read(10) # dump
+        # Seek to the start location, relative to the current position
+        # right after the header.
+        f.seek(record_length_bytes * start_record, 1)
         
-    #print recordNumber
-    #print index
+        # Keep reading till the file is finished
+        while f.tell() < fileLength and records_read < n_records_to_read:
+            # Skip the last record if requested, which usually contains
+            # incomplete data
+            if ignore_last_record and f.tell() == (
+                fileLength - record_length_bytes):
+                break
+            
+            # Read the timestamp for this record
+            # litte-endian 64-bit signed integer
+            timestamps.append(np.fromfile(f, np.dtype('<i8'), 1))
         
-    ch['header'] = header 
-    ch['timestamps'] = timestamps[0:recordNumber]
-    ch['data'] = samples[0:indices[recordNumber]]  # OR use downsample(samples,1), to save space
-    ch['recordingNumber'] = recordingNumbers[0:recordNumber]
-    f.close()
-    return ch
+            # Read the number of samples in this record
+            # little-endian 16-bit unsigned integer
+            N = np.fromfile(f, np.dtype('<u2'), 1).item() 
+            if N != header['blockLength']:
+                raise IOError('Found corrupted record in block ' + 
+                    str(recordNumber))
+            
+            # Read and store the recording numbers
+            # big-endian 16-bit unsigned integer
+            recordingNumbers.append(np.fromfile(f, np.dtype('>u2'), 1))
+            
+            # Read the data
+            # big-endian 16-bit signed integer
+            data = np.fromfile(f, np.dtype('>i2'), N)
+            if len(data) != N:
+                raise IOError("could not load the right number of samples")
+            
+            # Optionally convert dtype
+            if dtype == float: 
+                data = data * header['bitVolts']
+                        
+            # Store the data
+            samples.append(data)
+
+            # Extract and test the record marker
+            record_marker = np.fromfile(f, np.dtype('<u1'), 10)
+            if np.any(record_marker != spec_record_marker):
+                raise IOError("corrupted record marker at record %d" %
+                    records_read)
+            
+            # Update the count
+            samples_read += len(samples)            
+            records_read += 1
+
+    # Concatenate results, or empty arrays if no data read (which happens
+    # if start_sample is after the end of the data stream)
+    res = {'header': header}
+    if samples_read > 0:
+        res['timestamps'] = np.concatenate(timestamps)
+        res['data'] = np.concatenate(samples)
+        res['recordingNumber'] = np.concatenate(recordingNumbers)
+    else:
+        res['timestamps'] = np.array([], dtype=np.int)
+        res['data'] = np.array([], dtype=dtype)
+        res['recordingNumber'] = np.array([], dtype=np.int)
+    return res
     
 def loadSpikes(filepath):
     
@@ -322,11 +378,51 @@ def loadEvents(filepath):
     return data
     
 def readHeader(f):
-    header = { }
-    h = f.read(1024).replace('\n','').replace('header.','')
-    for i,item in enumerate(h.split(';')):
-        if '=' in item:
-            header[item.split(' = ')[0]] = item.split(' = ')[1]
+    """Read header information from the first 1024 bytes of an OpenEphys file.
+    
+    Args:
+        f: An open file handle to an OpenEphys file
+    
+    Returns: dict with the following keys.
+        - bitVolts : float, scaling factor, microvolts per bit
+        - blockLength : int, e.g. 1024, length of each record (see 
+            loadContinuous)
+        - bufferSize : int, e.g. 1024
+        - channel : the channel, eg "'CH1'"
+        - channelType : eg "'Continuous'"
+        - date_created : eg "'15-Jun-2016 21212'" (What are these numbers?)
+        - description : description of the file format
+        - format : "'Open Ephys Data Format'"
+        - header_bytes : int, e.g. 1024
+        - sampleRate : float, e.g. 30000.
+        - version: eg '0.4'
+        Note that every value is a string, even numeric data like bitVolts.
+        Some strings have extra, redundant single apostrophes.
+    """
+    header = {}
+    
+    # Read the data as a string
+    # Remove newlines and redundant "header." prefixes
+    # The result should be a series of "key = value" strings, separated
+    # by semicolons.
+    header_string = f.read(1024).replace('\n','').replace('header.','')
+    
+    # Parse each key = value string separately
+    for pair in header_string.split(';'):
+        if '=' in pair:
+            key, value = pair.split(' = ')
+            key = key.strip()
+            value = value.strip()
+            
+            # Convert some values to numeric
+            if key in ['bitVolts', 'sampleRate']:
+                header[key] = float(value)
+            elif key in ['blockLength', 'bufferSize', 'header_bytes']:
+                header[key] = int(value)
+            else:
+                # Keep as string
+                header[key] = value
+
     return header
     
 def downsample(trace,down):
@@ -352,154 +448,73 @@ def writeChannelMapFile(mapping, filename='mapping.prb'):
                       outfile, \
                       indent = 4, separators = (',', ': ') \
                  ) 
+
+def chunked_pack(folderpath, filename='openephys.dat', dref=None,
+    chunk_size=4000, start_record=None, stop_record=None, verbose=True):
+    """Read OpenEphys formatted data in chunks and write to a flat binary file.
     
-def pack(folderpath,source='100',**kwargs):  
-#convert single channel open ephys channels to a .dat file for compatibility with the KlustaSuite, Neuroscope and Klusters
-#should not be necessary for versions of open ephys which write data into HDF5 format.  
-#loads .continuous files in the specified folder and saves a .DAT in that folder
-#optional arguments:
-#   source: string name of the source that openephys uses as the prefix. is usually 100, if the headstage is the first source added, but can specify something different
-#
-#   data: pre-loaded data to be packed into a .DAT 
-#   dref: int specifying a channel # to use as a digital reference. is subtracted from all channels.
-#   order: the order in which the .continuos files are packed into the .DAT. should be a list of .continious channel numbers. length must equal total channels.
-#   suffix: appended to .DAT filename, which is openephys.DAT if no suffix provided.
+    Reading in chunks means that it is not necessary to hold the entire
+    dataset in memory at once.
 
-    #load the openephys data into memory
-    if 'data' not in kwargs.keys():
-        if 'channels' not in kwargs.keys():
-            data = loadFolder(folderpath)
-        else:   
-            data = loadFolder(folderpath,channels=kwargs['channels'])
-    else:
-        data = kwargs['data']
-    #if specified, do the digital referencing
-    if 'dref' in kwargs.keys():
-        ref =load(os.path.join(folderpath,''.join((source,'_CH',str(kwargs['dref']),'.continuous'))))
-        for i,channel in enumerate(data.keys()):
-            data[channel]['data'] = data[channel]['data'] - ref['data']   
-    #specify the order the channels are written in
-    if 'order' in kwargs.keys():
-        order = kwargs['order']
-    else:
-        order = data.keys()                         
-    #add a suffix, if one was specified        
-    if 'suffix' in kwargs.keys():
-        suffix=kwargs['suffix']
-    else:
-        suffix=''
-
-    #make a file to write the data back out into .dat format
-    outpath = os.path.join(folderpath,''.join(('openephys',suffix,'.dat')))
-    out = open(outpath,'wb')
-    
-    #go through the data and write it out in the .dat format
-    #.dat format specified here: http://neuroscope.sourceforge.net/UserManual/data-files.html
-    channelOrder = []
-    print ''.join(('...saving .dat to ',outpath,'...'))
-    bar = ProgressBar(len(data[data.keys()[0]]['data']))#progressbar.ProgressBar(maxval=1, widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage()])
-    for i in range(len(data[data.keys()[0]]['data'])):
-        for j in range(len(order)):
-            if source in data.keys()[0]:
-                ch = data[order[j]]['data']
-            else:        
-                ch = data[''.join(('CH',str(order[j]).replace('CH','')))]['data']
-            out.write(struct.pack('h',ch[i]))#signed 16-bit integer
-            #figure out which order this thing packed the channels in. only do this once.
-            if i == 0:
-                channelOrder.append(order[j])
-        #update how mucb we have list
-        if i%(len(data[data.keys()[0]]['data'])/100)==0:
-            bar.animate(i)
-            #bar.update(float(i+1)/float(len(data[data.keys()[0]])))
-    #bar.finish()
-    out.close()      
-    print ''.join(('order: ',str(channelOrder)))
-    print ''.join(('.dat saved to ',outpath))
-    
-#**********************************************************
-# progress bar class used to show progress of pack()
-    #stolen from some post on stack overflow
-import sys
-try:
-    from IPython.display import clear_output
-    have_ipython = True
-except ImportError:
-    have_ipython = False
-class ProgressBar:
-    def __init__(self, iterations):
-        self.iterations = iterations
-        self.prog_bar = '[]'
-        self.fill_char = '*'
-        self.width = 40
-        self.__update_amount(0)
-        if have_ipython:
-            self.animate = self.animate_ipython
-        else:
-            self.animate = self.animate_noipython
-
-    def animate_ipython(self, iter):
-        print '\r', self,
-        sys.stdout.flush()
-        self.update_iteration(iter + 1)
-
-    def update_iteration(self, elapsed_iter):
-        self.__update_amount((elapsed_iter / float(self.iterations)) * 100.0)
-        self.prog_bar += '  %d of %s complete' % (elapsed_iter, self.iterations)
-
-    def __update_amount(self, new_amount):
-        percent_done = int(round((new_amount / 100.0) * 100.0))
-        all_full = self.width - 2
-        num_hashes = int(round((percent_done / 100.0) * all_full))
-        self.prog_bar = '[' + self.fill_char * num_hashes + ' ' * (all_full - num_hashes) + ']'
-        pct_place = (len(self.prog_bar) // 2) - len(str(percent_done))
-        pct_string = '%d%%' % percent_done
-        self.prog_bar = self.prog_bar[0:pct_place] + \
-            (pct_string + self.prog_bar[pct_place + len(pct_string):])
-
-    def __str__(self):
-        return str(self.prog_bar)
-#*************************************************************
-
-def pack_2(folderpath, filename='openephys.dat', source='100', 
-    channels='all', dref=None, recording=None):
-
-    '''Alternative version of pack which uses numpy's tofile function to write data.
-    pack_2 is much faster than pack and avoids quantization noise incurred in pack due
-    to conversion of data to float voltages during loadContinous followed by rounding
-    back to integers for packing.  
-
-    source: string name of the source that openephys uses as the prefix. It is usually 100, 
-            if the headstage is the first source added, but can specify something different.
-
-    channels:  List of channel numbers specifying order in which channels are packed. By default
-               all CH continous files are packed in numerical order.
+    folderpath : string, path to folder containing all channels
 
     dref:  Digital referencing - either supply a channel number or 'ave' to reference to the 
            average of packed channels.
     
-    recording : None, or int
-        If there is only one recording in the folder, leave as None.
-        Otherwise, specify the number of the recording as an integer.
-    '''
+    chunk_size : the number of records (not bytes or samples!) to read at
+        once. 4000 records of 64-channel data requires ~500 MB of memory.
+    
+    **kwargs : source, channels, recording, ignore_last_record
+        Passed to loadFolderToArray
+    """
+    # Get header info to determine how many records we have to pack
+    header = get_header_from_folder(folderpath, source=source,
+        channels=channels, recording=recording)
+    if start_record is None:
+        start_record = 0
+    if stop_record is None:
+        stop_record = header['n_records']
+    
+    # Iterate over chunks
+    for chunk_start in range(start_record, stop_record, chunk_size):
+        # Determine where the chunk stops
+        chunk_stop = np.min([stop_record, chunk_start + chunk_size])
+        if verbose:
+            print "loading chunk from %d to %d" % (chunk_start, chunk_stop)
+        
+        # Load the chunk
+        data_array = loadFolderToArray(folderpath, dtype=np.int16,
+            start_record=chunk_start, stop_record=chunk_stop,
+            verbose=False, **kwargs)
 
-    data_array = loadFolderToArray(folderpath, channels, np.int16, source,
-        recording=recording)
+        # This only happens if we happen to be loading a chunk consisting
+        # of only the last record, and also ignore_last_record is True
+        if len(data_array) == 0:
+            break
 
-    if dref: 
-        if dref == 'ave':
-            print('Digital referencing to average of all channels.')
-            reference = np.mean(data_array,1)
-        else:
-            print('Digital referencing to channel ' + str(dref))
-            if channels == 'all': 
-                channels = _get_sorted_channels(folderpath)
-            reference = deepcopy(data_array[:,channels.index(dref)])
-        for i in range(data_array.shape[1]):
-            data_array[:,i] = data_array[:,i] - reference
-
-    print('Packing data to file: ' + filename)
-    data_array.tofile(os.path.join(folderpath,filename))
+        # Digital referencing
+        if dref: 
+            # Choose a reference
+            if dref == 'ave':
+                reference = np.mean(data_array, 1)
+            else:
+                # Figure out which channels are included
+                if 'channels' in kwargs and kwargs['channels'] != 'all':
+                    channels = kwargs['channels']
+                else:
+                    channels = _get_sorted_channels(folderpath)
+                
+                # Find the reference channel
+                dref_idx = channels.index(dref)
+                reference = data_array[:, dref_idx].copy()
+            
+            # Subtract the reference
+            for i in range(data_array.shape[1]):
+                data_array[:,i] = data_array[:,i] - reference
+        
+        # Explicity open in append mode so we don't just overwrite
+        with file(os.path.join(folderpath, filename), 'ab') as fi:
+            data_array.tofile(fi)
 
 def regex_capture(pattern, list_of_strings, take_index=0):
     """Apply regex `pattern` to each string and return a captured group.
@@ -549,5 +564,107 @@ def _get_sorted_channels(folderpath, recording=None):
         channel_numbers_s = regex_capture(regex_pattern, os.listdir(folderpath))
         channel_numbers_int = map(int, channel_numbers_s)
         return sorted(channel_numbers_int)
+
+def get_number_of_records(filepath):
+    # Open the file
+    with file(filepath, 'rb') as f:
+        # Read header info
+        header = readHeader(f)
         
+        # Get file length
+        fileLength = os.fstat(f.fileno()).st_size
         
+        # Determine the number of records
+        record_length_bytes = 2 * header['blockLength'] + 22
+        n_records = int((fileLength - 1024) / record_length_bytes)
+        if (n_records * record_length_bytes + 1024) != fileLength:
+            raise IOError("file does not divide evenly into full records")
+    
+    return n_records
+
+def get_filelist(folderpath, source='100', channels='all', recording=None):
+    """Given a folder of data files and a list of channels, get filenames.
+    
+    folderpath : string, folder containing OpenEphys data files
+    source : string, typically '100'
+    channels : list of numeric channel numbers to acquire
+        If 'all', then _get_sorted_channels is used to get all channels
+        from that folder in sorted order
+    recording : the recording number, or None if there is only one recording
+    
+    Returns: a list of filenames corresponding one-to-one to the channels
+        in `channels`. The filenames must be joined with `folderpath` to
+        construct a full filename.
+    """
+    # Get all channels if requested
+    if channels == 'all': 
+        channels = _get_sorted_channels(folderpath, recording=recording)    
+    
+    # Get the list of continuous filenames
+    if recording is None or recording == 1:
+        # The first recording has no suffix
+        filelist = ['%s_CH%d.continuous' % (source, chan)
+            for chan in channels]
+    else:
+        filelist = ['%s_CH%d_%d.continuous' % (source, chan, recording)
+            for chan in channels]    
+    
+    return filelist
+
+def get_header_from_folder(folderpath, filelist=None, **kwargs):
+    """Return the header info for all files in `folderpath`.
+    
+    The header for each file is loaded individually. The following keys
+    are supposed to be the same for every file:
+        ['bitVolts', 'blockLength', 'bufferSize', 'date_created',
+        'description', 'format', 'header_bytes', 'sampleRate', 'version']
+    They are checked for consistency and returned in a single dict.    
+    
+    Finally the number of records is also checked for each file, checked
+    for consistency, and returned as the key 'n_records'.
+    
+    folderpath : folder containing OpenEphys data files
+    filelist : list of filenames within `folderpath` to load
+        If None, then provide optional keyword arguments `source`, 
+        `channels`, and/or `recording`. They are passed to `get_filelist`
+        to get the filenames in this folder.
+    
+    Returns: dict
+    """
+    included_keys = ['blockLength', 'bufferSize', 'date_created',
+        'description', 'format', 'header_bytes', 'version', 'n_records']
+    included_float_keys = ['bitVolts', 'sampleRate']
+    
+    # Get filelist if it was not provided
+    if filelist is None:
+        filelist = get_filelist(folderpath, **kwargs)
+    
+    # Get header for each file, as well as number of records
+    header_l = []
+    for filename in filelist:
+        full_filename = os.path.join(folderpath, filename)
+        with file(full_filename) as fi:
+            header = readHeader(fi)
+        header['n_records'] = get_number_of_records(full_filename)
+        header_l.append(header)
+    if len(header_l) == 0:
+        raise IOError("no headers could be loaded")
+    
+    # Form a single header based on all of them, starting with the first one
+    unique_header = {}
+    for key in included_keys + included_float_keys:
+        unique_header[key] = header_l[0][key]
+    
+    # Check every header
+    for header in header_l:
+        # Check the regular keys
+        for key in included_keys:
+            if unique_header[key] != header[key]:
+                raise ValueError("inconsistent header info in key %s" % key)
+        
+        # Check the floating point keys
+        for key in included_float_keys:
+            if not np.isclose(unique_header[key], header[key]):
+                raise ValueError("inconsistent header info in key %s" % key)
+            
+    return unique_header

--- a/OpenEphys.py
+++ b/OpenEphys.py
@@ -144,9 +144,20 @@ def loadContinuous(filepath, dtype = float):
         
 #    f.close
     # pre-allocate samples
+    
+    # Data is loaded in records of size 1024 samples, one timestamp per record
+    
+    # This is where the data will go
     samples = np.zeros(MAX_NUMBER_OF_CONTINUOUS_SAMPLES, dtype)
+    
+    # This is where the timestamps will go
     timestamps = np.zeros(MAX_NUMBER_OF_RECORDS)
+    
+    # This might be the recording number?
     recordingNumbers = np.zeros(MAX_NUMBER_OF_RECORDS)
+    
+    # This is used to figure out how to assign into the predetermined `samples`
+    # array.
     indices = np.arange(0,MAX_NUMBER_OF_RECORDS*SAMPLES_PER_RECORD, SAMPLES_PER_RECORD, np.dtype(np.int64))
     
     #read in the data
@@ -159,10 +170,13 @@ def loadContinuous(filepath, dtype = float):
     #print f.tell()
     
     while f.tell() < fileLength:
-        
+        # Increment the record count
         recordNumber += 1        
         
+        # Read timestamp for this record
         timestamps[recordNumber] = np.fromfile(f,np.dtype('<i8'),1) # little-endian 64-bit signed integer 
+        
+        # Read the number of samples in this record
         N = np.fromfile(f,np.dtype('<u2'),1) # little-endian 16-bit unsigned integer
         
         #print index
@@ -170,13 +184,16 @@ def loadContinuous(filepath, dtype = float):
         if N != SAMPLES_PER_RECORD:
             raise Exception('Found corrupted record in block ' + str(recordNumber))
         
+        # Read and store the recording numbers
         recordingNumbers[recordNumber] = (np.fromfile(f,np.dtype('>u2'),1)) # big-endian 16-bit unsigned integer
         
+        # Convert the dtype
         if dtype == float: # Convert data to float array and convert bits to voltage.
             data = np.fromfile(f,np.dtype('>i2'),N) * float(header['bitVolts']) # big-endian 16-bit signed integer, multiplied by bitVolts   
         else:  # Keep data in signed 16 bit integer format.
             data = np.fromfile(f,np.dtype('>i2'),N)  # big-endian 16-bit signed integer
         try:
+            # Assign data into samples, using indices
             samples[indices[recordNumber]:indices[recordNumber+1]] = data            
         except ValueError:
             print type(index)


### PR DESCRIPTION
When there is more than one recording in a session, recordings after the first have an incremental label appened ("_2", "_3", etc). I couldn't find any existing Python code for loading such recordings. It's a simple fix to add a suffix like '_2' for the second recording. This is my first pull request so just let me know if I should submit it in some other way.