### PR TITLE
Changed default output format of load_open_ephys_data_faster.m to preserve data resolution

### DIFF
--- a/load_open_ephys_data_faster.m
+++ b/load_open_ephys_data_faster.m
@@ -1,17 +1,22 @@
-function [data, timestamps, info] = load_open_ephys_data_faster(filename)
+function [data, timestamps, info] = load_open_ephys_data_faster(filename, varargin)
 %
-% [data, timestamps, info] = load_open_ephys_data(filename)
+% [data, timestamps, info] = load_open_ephys_data(filename, [outputFormat])
 %
 %   Loads continuous, event, or spike data files into Matlab.
 %
 %   Inputs:
 %
 %     filename: path to file
+%     outputFormat: (optional) If omitted, continuous data is output in double format and is scaled to reflect microvolts. 
+%                   If this argument is 'unscaledInt16' and the file contains continuous data, the output data will be in
+%                   int16 format and will not be scaled; this data must be manually converted to a floating-point format
+%                   and multiplied by info.header.bitVolts to obtain microvolt values. This feature is intended to save memory
+%                   for operations involving large amounts of data.
 %
 %
 %   Outputs:
 %
-%     data: either an array continuous samples (in microvolts),
+%     data: either an array continuous samples (in microvolts unless outputFormat is specified, see above),
 %           a matrix of spike waveforms (in microvolts),
 %           or an array of event channels (integers)
 %
@@ -53,6 +58,17 @@ function [data, timestamps, info] = load_open_ephys_data_faster(filename)
 [~,~,filetype] = fileparts(filename);
 if ~any(strcmp(filetype,{'.events','.continuous','.spikes'}))
     error('File extension not recognized. Please use a ''.continuous'', ''.spikes'', or ''.events'' file.');
+end
+
+bInt16Out = false;
+if nargin > 2
+    error('Too many input arguments.');
+elseif nargin == 2
+    if strcmpi(varargin{1}, 'unscaledInt16')
+        bInt16Out = true;
+    else
+        error('Unrecognized output format.');
+    end
 end
 
 fid = fopen(filename);
@@ -117,7 +133,14 @@ switch filetype
         info.nsamples = segRead('nsamples');
         if ~all(info.nsamples == SAMPLES_PER_RECORD)&& version >= 0.1, error('Found corrupted record'); end
         if version >= 0.2, info.recNum = segRead('recNum'); end
-        data = segRead_data('data', 'b').*info.header.bitVolts; % read in continuousdata
+        
+        % read in continuous data
+        if bInt16Out
+            data = segRead_int16('data', 'b');
+        else
+            data = segRead('data', 'b') .* info.header.bitVolts;
+        end
+        
         if nargout>1 % do not create timestamp arrays unless they are requested
             timestamps = nan(size(data));
             current_sample = 0;
@@ -139,7 +162,7 @@ switch filetype
 end
 fclose(fid);
 
-function seg = segRead_data(segName, mf)
+function seg = segRead_int16(segName, mf)
     %% This function is specifically for reading continuous data. 
     %  It keeps the data in int16 precision, which can drastically decrease
     %  memory consumption


### PR DESCRIPTION
Based on issue #30. The update adds an optional 'outputFormat' argument to the function. When this argument is omitted, continuous data will be scaled by bitVolts and output in double format (the same behavior as load_open_ephys_data.m), which solves an issue where reading data as int16s and then scaling them caused them to be rerounded, decreasing the resolution. However, since reading data as int16s is helpful in memory-sensitive applications, setting outputFormat to 'unscaledInt16' causes the function to output the raw, unscaled int16s. These values must be multiplied by info.header.bitVolts (as doubles or floats) to obtain microvolt values.

I removed the previous behavior of this function, outputting scaled int16s, because it causes data degradation. However, this change makes the default behavior consistent with that of load_open_ephys_data.m.