### PR TITLE
Fix selection of first rec for loading channel_bit_volts

### DIFF
--- a/Python3/Kwik.py
+++ b/Python3/Kwik.py
@@ -42,7 +42,8 @@ def load(filename, dataset=0):
             data['data'] = {Rec: f['recordings'][Rec]['data']
                             for Rec in f['recordings'].keys()}
             
-            if 'channel_bit_volts' in f['recordings']['0']\
+            R = list(f['recordings'])[0]
+            if 'channel_bit_volts' in f['recordings'][R]\
                                        ['application_data'].keys():
                 data['channel_bit_volts'] = {Rec: f['recordings'][Rec]\
                                                    ['application_data']\


### PR DESCRIPTION
In our Kwik datasets, not always the rec '0' is present. This commit fix KeyErrors that would happen when checking if 'channel_bit_volts' is present in the file.