### PR TITLE
Implement a "settings.xml" reader

### DIFF
--- a/Python3/SettingsXML.py
+++ b/Python3/SettingsXML.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 20170704 21:15:19
+
+@author: Thawann Malfatti
+
+Loads info from the settings.xml file.
+
+Examples:
+    File = '/Path/To/Experiment/settings.xml
+    
+    # To get all info the xml file can provide:
+    AllInfo = SettingsXML.XML2Dict(File)
+    
+    # AllInfo will be a dictionary following the same structure of the XML file.
+    
+    # To get info only about channels recorded:
+    RecChs = SettingsXML.GetRecChs(File)
+    
+    # RecChs will be a dictionary:
+    # 
+    # RecChs
+    #     ProcessorNodeId
+    #         ChIndex
+    #             'name'
+    #             'number'
+    #             'gain'
+    #         'PluginName'
+
+"""
+
+from xml.etree import ElementTree
+
+
+def Root2Dict(El):
+    Dict = {}
+    if El.getchildren(): 
+        for SubEl in El:
+            if SubEl.keys():
+                if SubEl.get('name'): 
+                    if SubEl.tag not in Dict: Dict[SubEl.tag] = {}
+                    Dict[SubEl.tag][SubEl.get('name')] = Root2Dict(SubEl)
+                
+                    Dict[SubEl.tag][SubEl.get('name')].update(
+                        {K: SubEl.get(K) for K in SubEl.keys() if K is not 'name'}
+                    )
+                
+                else: 
+                    Dict[SubEl.tag] = Root2Dict(SubEl)
+                    Dict[SubEl.tag].update(
+                        {K: SubEl.get(K) for K in SubEl.keys() if K is not 'name'}
+                    )
+                    
+                
+            else: Dict[SubEl.tag] = Root2Dict(SubEl)
+    else:
+        if El.items(): Dict[El.tag] = dict(El.items())
+        else: Dict[El.tag] = El.text
+    
+    
+    return(Dict)
+
+
+def XML2Dict(File):
+    Tree = ElementTree.parse(File); Root = Tree.getroot()
+    Info = Root2Dict(Root)
+    
+    return(Info)
+
+
+def GetRecChs(File):
+    Info = XML2Dict(File)
+    RecChs = {}
+    
+    for P, Proc in Info['SIGNALCHAIN']['PROCESSOR'].items():
+        if 'CHANNEL_INFO' not in Proc: continue
+        
+        for C, Ch in Proc['CHANNEL_INFO']['CHANNEL'].items():
+            ChNo = Ch['CHANNEL']['number']
+            Rec = Proc['CHANNEL'][ChNo]['SELECTIONSTATE']['SELECTIONSTATE']['record']
+            if Rec:
+                if Proc['NodeId'] not in RecChs: RecChs[Proc['NodeId']] = {}
+                RecChs[Proc['NodeId']][ChNo] = Ch['CHANNEL']
+        
+        RecChs[Proc['NodeId']]['PluginName'] = Proc['pluginName']
+    
+    return(RecChs)
+

--- a/Python3/SettingsXML.py
+++ b/Python3/SettingsXML.py
@@ -15,7 +15,10 @@ Examples:
     # AllInfo will be a dictionary following the same structure of the XML file.
     
     # To get info only about channels recorded:
-    RecChs = SettingsXML.GetRecChs(File)
+    RecChs = SettingsXML.GetRecChs(File)[0]
+    
+    # To get also the processor names:
+    RecChs, PluginNames = SettingsXML.GetRecChs(File)
     
     # RecChs will be a dictionary:
     # 
@@ -70,7 +73,7 @@ def XML2Dict(File):
 
 def GetRecChs(File):
     Info = XML2Dict(File)
-    RecChs = {}
+    RecChs = {}; ProcNames = {}
     
     for P, Proc in Info['SIGNALCHAIN']['PROCESSOR'].items():
         if 'CHANNEL_INFO' not in Proc: continue
@@ -82,7 +85,7 @@ def GetRecChs(File):
                 if Proc['NodeId'] not in RecChs: RecChs[Proc['NodeId']] = {}
                 RecChs[Proc['NodeId']][ChNo] = Ch['CHANNEL']
         
-        RecChs[Proc['NodeId']]['PluginName'] = Proc['pluginName']
+        ProcNames[Proc['NodeId']] = Proc['pluginName']
     
-    return(RecChs)
+    return(RecChs, ProcNames)
 


### PR DESCRIPTION
According to the Flat-binary data format section in the wiki, "[...] because there's no extra information in the file, it requires that you keep track of the number of channels are saved in your dataset, as well as their ordering". Hopefully, we have the settings.xml file which contains a lot of useful info. Thus, I wrote this little functions to parse this XML file and return all info, or specific info about channels that were selected for recording in any processor. Although this functions can be useful for recordings in any format, I think it'll be particularly useful for Flat-binary recordings. 