### PR TITLE
Fix selection of recording channels in non-source processors

### DIFF
--- a/Python3/SettingsXML.py
+++ b/Python3/SettingsXML.py
@@ -91,10 +91,12 @@ def GetRecChs(File):
         if 'CHANNEL_INFO' in Proc:
             for Ch in Proc['CHANNEL_INFO']['CHANNEL'].values():
                 RecChs = FindRecProcs(Ch, Proc, RecChs)
-        
-        else:
+            
+        elif 'CHANNEL' in Proc:
             for Ch in Proc['CHANNEL'].values():
                 RecChs = FindRecProcs(Ch, Proc, RecChs)
+            
+        else: continue
         
         if 'pluginName' in Proc:
             ProcNames[Proc['NodeId']] = Proc['pluginName']


### PR DESCRIPTION
Before these changes, info about data recorded from non-source plugins were ignored. Now, the `RecChs` output dictionary will contain information of recording channels from all processors with recording enabled.