### PR TITLE
Add scaling option for MatData2Kwd

### DIFF
--- a/MatData2Kwd.m
+++ b/MatData2Kwd.m
@@ -1,16 +1,18 @@
-function MatData2Kwd(data,Output,Name,Fs)
+function MatData2Kwd(data,Output,Name,Fs,varargin)
 %MatData2Kwd Function to convert matlab data to kwd. (Open Ephys GUI 
 % compatible file). Variable data must be a ch x samples matrix. For LFP
 % signal models, generated in matlab and fluctuating from -1 to 1, we
 % recommend a multiplication of 1000 for better visualization on LFP viewer.
 %
 % 
-% MatData2Kwd(data,Output,Name,Fs)
+% MatData2Kwd(data,Output,Name,Fs,[scale]=false)
 %   data is a matrix of Channels x Record data; Output is the folder adress
 %   which .kwd file will be saved; Name is the string which will name your
 %   file; Fs is the frequency sample or sample rate of your matrix. We 
 %   recommend to use the same sample rate as the options avaible in the
-%   Rhythm FPGA in Open Ephys GUI
+%   Rhythm FPGA in Open Ephys GUI. If scale is set to true, rescales the
+%   data assuming a bitVolts value of 0.195, such that the data is
+%   displayed at the same scale in the GUI.
 %
 %   Example: 
 % 
@@ -23,10 +25,20 @@ function MatData2Kwd(data,Output,Name,Fs)
 %   MatData2Kwd(data,'/home/yourDirectory/GUI/','SampleFile',Fs)
 %
 
-    narginchk(4,4)
+    narginchk(4,5)
+    
+    bit_volts = 0.195;
+    scale_val = 1;
+    if varargin{1}
+        scale_val = bit_volts;
+    end
         
     kwdfile = [Output Name '.kwd'];
-    internal_path = ['/recordings/0'];
+    internal_path = '/recordings/0';
+    
+    if numel(dir(kwdfile))
+        delete(kwdfile);
+    end
 
     h5create(kwdfile, [internal_path '/data'], ...
         [size(data,1) size(data,2)], ...
@@ -35,11 +47,11 @@ function MatData2Kwd(data,Output,Name,Fs)
     h5writeatt(kwdfile,'/recordings/0','name',Name);
     h5writeatt(kwdfile,'/recordings/0','start_time',0);
     h5writeatt(kwdfile,'/recordings/0','sample_rate',Fs);
-    h5writeatt(kwdfile,'/recordings/0','bit_depth',(0.195));
+    h5writeatt(kwdfile,'/recordings/0','bit_depth',bit_volts);
     h5writeatt(kwdfile, '/', 'kwik_version', 2);
              
 
-    this_block = int16(data);
+    this_block = int16(data/scale_val);
                     
     h5write(kwdfile,'/recordings/0/data', ...
             this_block);

--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -141,7 +141,7 @@ for processor = 1:size(info.processors,1)
                     h5writeatt(kwdfile, internal_path, 'bit_depth', info_continuous.header.bitVolts);
                     h5create(kwdfile, [internal_path '/bit_depth'], [1 1],...
                         'Datatype', 'double');
-                    h5write(kwdfile, [internal_path '/sample_rate'], (info_continuous.header.bitVolts));
+                    h5write(kwdfile, [internal_path '/bit_depth'], (info_continuous.header.bitVolts));
 
                     h5create(kwdfile, [internal_path '/application_data/channel_bit_volts'], [1 1], ...
                         'DataType', 'double');


### PR DESCRIPTION
This is a simple enhancement in the function to convert MATLAB data to kwd format. If the fifth input is set to true, the data is automatically scaled by 0.195 before converting to int16 format and writing to the file, mirroring the conversion that occurs when in the functions that load data from OpenEphys format. The default is still to not do this, for backward compatibility. I'm assuming here that 0.195 is always the bitVolts value (for now), since it was already hard-coded in here as the kwd bit_depth attribute.

Also added a line to delete the kwd file before writing if it already exists, which should prevent that annoying error about the record already existing from the hdf5 library.