### PR TITLE
timestamps output for xx.continuous files

### DIFF
--- a/load_open_ephys_data_faster.m
+++ b/load_open_ephys_data_faster.m
@@ -148,6 +148,7 @@ switch filetype
                 timestamps(current_sample+1:current_sample+info.nsamples(record)) = info.ts(record):info.ts(record)+info.nsamples(record)-1;
                 current_sample = current_sample + info.nsamples(record);
             end
+            timestamps = timestamps./info.header.sampleRate;
         end
     case '.spikes'
         timestamps = segRead('timestamps')./info.header.sampleRate;


### PR DESCRIPTION
Not sure if my operating system (Ubuntu 14.04) is related to this issue, but my version of load_open_ephys_data_faster.m loads the .continuous timestamps as "0 1 2 3 4 5 ... n ..." etc. (the n-th sample number), rather than giving the timestamps in seconds. This change outputs the timestamps in seconds.