### PR TITLE
Fixes to 2 scaling bugs in convert_open_ephys_to_kwik.m

### DIFF
--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -141,7 +141,7 @@ for processor = 1:size(info.processors,1)
                     h5writeatt(kwdfile, internal_path, 'bit_depth', info_continuous.header.bitVolts);
                     h5create(kwdfile, [internal_path '/bit_depth'], [1 1],...
                         'Datatype', 'double');
-                    h5write(kwdfile, [internal_path '/sample_rate'], (info_continuous.header.bitVolts));
+                    h5write(kwdfile, [internal_path '/bit_depth'], (info_continuous.header.bitVolts));
 
                     h5create(kwdfile, [internal_path '/application_data/channel_bit_volts'], [1 1], ...
                         'DataType', 'double');

--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -90,7 +90,8 @@ for processor = 1:size(info.processors,1)
         h5write(kwdfile, '/kwik_version', int16(2));
         h5writeatt(kwdfile, '/', 'kwik_version', 2);
 
-        for ch = 1:length(recorded_channels)
+        num_channels = length(recorded_channels);
+        for ch = 1:num_channels
 
             filename_in = [input_directory filesep ...
                 int2str(info.processors{processor, 1}) ...
@@ -123,31 +124,20 @@ for processor = 1:size(info.processors,1)
                     end
     
                     h5create(kwdfile, [internal_path '/data'], ...
-                        [numel(recorded_channels) numel(this_block)], ...
+                        [num_channels numel(this_block)], ...
                         'Datatype', 'int16', ...
                         'ChunkSize', [1 numel(this_block)]);
                     
                     h5writeatt(kwdfile, internal_path, 'start_sample', int64(timestamps(start_sample)));
                     h5writeatt(kwdfile, internal_path, 'sample_rate', int16(info_continuous.header.sampleRate));
 
-                    h5create(kwdfile, [internal_path '/start_sample'], [1 1],...
-                        'Datatype', 'int64');
-                    h5write(kwdfile, [internal_path '/start_sample'], int64(timestamps(start_sample)));
-                        
-                    h5create(kwdfile, [internal_path '/sample_rate'], [1 1],...
-                        'Datatype', 'int16');
-                    h5write(kwdfile, [internal_path '/sample_rate'], int16(info_continuous.header.sampleRate));
-
                     h5writeatt(kwdfile, internal_path, 'bit_depth', info_continuous.header.bitVolts);
-                    h5create(kwdfile, [internal_path '/bit_depth'], [1 1],...
-                        'Datatype', 'double');
-                    h5write(kwdfile, [internal_path '/bit_depth'], (info_continuous.header.bitVolts));
-
-                    h5create(kwdfile, [internal_path '/application_data/channel_bit_volts'], [1 1], ...
+                    h5create(kwdfile, [internal_path '/application_data/channel_bit_volts'], [1 num_channels], ...
                         'DataType', 'double');
-                    h5write(kwdfile, [internal_path '/application_data/channel_bit_volts'], (info_continuous.header.bitVolts));
-                    h5writeatt(kwdfile, [internal_path '/application_data'], 'channel_bit_volts', (info_continuous.header.bitVolts));
                 end
+                
+                h5write(kwdfile, [internal_path '/application_data/channel_bit_volts'], ...
+                    info_continuous.header.bitVolts, [1 ch], [1 1]);
 
                 h5write(kwdfile,['/recordings/' int2str(X-1) '/data'], ...
                     (this_block(1:end))', [ch 1], [1 numel(this_block)]);

--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -97,7 +97,7 @@ for processor = 1:size(info.processors,1)
                 int2str(info.processors{processor, 1}) ...
                 '_CH' int2str(recorded_channels(ch)) '.continuous'];
 
-            [data, timestamps, info_continuous] = load_open_ephys_data(filename_in);
+            [data, timestamps, info_continuous] = load_open_ephys_data_faster(filename_in, 'unscaledInt16');
 
             recording_blocks = unique(info_continuous.recNum);
             block_size = info_continuous.header.blockLength;
@@ -110,8 +110,9 @@ for processor = 1:size(info.processors,1)
 
                 this_block = int16(data(start_sample:end_sample));
 
-                if ch == 1
-                    internal_path = ['/recordings/' int2str(X-1)];
+                internal_path = ['/recordings/' int2str(X-1)];
+
+                if ch == 1 % only create dataset and write attributes once per recording block
 
                     if processor_index == 1 % only write to the kwik file for the first processor
                         h5create(kwikfile, [internal_path '/start_sample'], [1 1],...
@@ -139,7 +140,7 @@ for processor = 1:size(info.processors,1)
                 h5write(kwdfile, [internal_path '/application_data/channel_bit_volts'], ...
                     info_continuous.header.bitVolts, [1 ch], [1 1]);
 
-                h5write(kwdfile,['/recordings/' int2str(X-1) '/data'], ...
+                h5write(kwdfile,[internal_path '/data'], ...
                     (this_block(1:end))', [ch 1], [1 numel(this_block)]);
 
             end

--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -51,7 +51,7 @@ info = get_session_info(input_directory);
 kwikfile = [get_full_path(output_directory) filesep ...
         'session_info.kwik'];
     
-disp(kwikfile)
+disp(['Writing ' kwikfile '...'])
     
 info.kwikfile = kwikfile;
     
@@ -86,6 +86,8 @@ for processor = 1:size(info.processors,1)
             delete(kwdfile);
         end
         
+        disp(['Writing ' kwdfile '...']);
+
         h5create(kwdfile, '/kwik_version', [1 1], 'Datatype', 'int16');
         h5write(kwdfile, '/kwik_version', int16(2));
         h5writeatt(kwdfile, '/', 'kwik_version', 2);


### PR DESCRIPTION
I've got a couple of fixes here for this function:

* First, noticed a typo in where "bit_depth" was saved, when it was saved as a dataset. However, this wasn't actually causing any issues since only the attribute version of "bit_depth" or "sample_rate" is actually used.
* Removed extraneous saves of attributes as datasets and vice versa
* The per-channel bit volts were being erroneously saved in a scalar dataset rather than a vector. As a result, in the OEP GUI, only the first channel would get the right bitVolts value, and the rest would get whatever junk was in the adjacent memory (causing wildly wrong amplitudes and saturation for these channels). Fixed this.
* The data to be converted was being loaded by load_open_ephys_data, which multiplies the data by the bitVolts value and converts to double. This isn't what we want since the kwd files should also save the data in int16 format. Fixed this using the 'unscaledInt16' option for load_open_ephys_data_faster.

Hope this is helpful!