### PR TITLE
Rework convert_open_ephys_to_kwik.m

### DIFF
--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -1,6 +1,5 @@
 function info = convert_open_ephys_to_kwik(varargin)
-
-% 
+%
 % Converts Open Ephys data to KWIK format
 %
 %   by Josh Siegle, November 2013
@@ -11,7 +10,6 @@ function info = convert_open_ephys_to_kwik(varargin)
 %  output_directory (optional): folder to save the KWIK files
 %    - defaults to using the input_directory
 %
-
 % KWIK file contains:
 % - metadata
 % - spikes times
@@ -44,160 +42,207 @@ end
 
 info = get_session_info(input_directory);
 
-%%
+% loop over experiments
 
-% 1. create the KWIK file
-
-kwikfile = [get_full_path(output_directory) filesep ...
-        'session_info.kwik'];
+for kE = 1:length(info)
     
-disp(['Writing ' kwikfile '...'])
+    experiment_prefix = ['experiment' num2str(kE)];
     
-info.kwikfile = kwikfile;
+    %%
     
-if numel(dir(kwikfile))
-    delete(kwikfile)
-end
-
-H5F.create(kwikfile);
-h5writeatt(kwikfile, '/', 'kwik_version', '2')
-
-
-%%
-
-% 2. create the KWD files
-
-processor_index = 0;
-
-for processor = 1:size(info.processors,1)
+    % 1. create the KWIK file
     
-    recorded_channels = info.processors{processor, 3};
+    kwikfile = [get_full_path(output_directory) filesep ...
+        experiment_prefix '_session_info.kwik'];
     
-    if ~isempty(recorded_channels)
-
+    disp(['Writing ' kwikfile '...'])
+    
+    info(kE).kwikfile = kwikfile;
+    
+    if numel(dir(kwikfile))
+        delete(kwikfile)
+    end
+    
+    H5F.create(kwikfile);
+    h5writeatt(kwikfile, '/', 'kwik_version', '2')
+    
+    
+    %%
+    
+    % 2. create the KWD files
+    
+    processor_index = 0;
+    
+    kwik_blocks_written = [];
+    
+    for processor = 1:size(info(kE).processors,1)
+        
+        recorded_channels = info(kE).processors{processor, 3};
+        
+        if isempty(recorded_channels)
+            continue;
+        end
+        
         processor_index = processor_index + 1;
-
+        
         % initialize this processor's kwd file
         kwdfile = [get_full_path(output_directory) filesep ...
-            int2str(info.processors{processor,1}) '_raw.kwd'];
-        info.kwdfiles{processor_index} = kwdfile;
-
+            experiment_prefix '_' ...
+            int2str(info(kE).processors{processor,1}) '_raw.kwd'];
+        info(kE).kwdfiles{processor_index} = kwdfile;
+        
         if numel(dir(kwdfile))
             delete(kwdfile);
         end
         
         disp(['Writing ' kwdfile '...']);
-
-        h5create(kwdfile, '/kwik_version', [1 1], 'Datatype', 'int16');
-        h5write(kwdfile, '/kwik_version', int16(2));
-        h5writeatt(kwdfile, '/', 'kwik_version', 2);
-
+        
+        H5F.create(kwdfile);
+        h5writeatt(kwdfile, '/', 'kwik_version', uint16(2));
+        
         num_channels = length(recorded_channels);
+        
+        blocks_created = [];
+        
         for ch = 1:num_channels
-
-            filename_in = [input_directory filesep ...
-                int2str(info.processors{processor, 1}) ...
-                '_CH' int2str(recorded_channels(ch)) '.continuous'];
-
+            
+            filename_in = recorded_channels{ch};
             [data, timestamps, info_continuous] = load_open_ephys_data_faster(filename_in, 'unscaledInt16');
-
+            
             recording_blocks = unique(info_continuous.recNum);
             block_size = info_continuous.header.blockLength;
-
-            for X = 1:length(recording_blocks)
-
-                in_block = find(info_continuous.recNum == recording_blocks(X));
+            
+            for block_num = recording_blocks' + 1 % make sure it's one-based so they can be used for indexing
+                
+                in_block = find(info_continuous.recNum == block_num - 1);
                 start_sample = (in_block(1)-1)*block_size+1;
                 end_sample = (in_block(end)-1)*block_size+block_size;
-
+                
                 this_block = int16(data(start_sample:end_sample));
-
-                internal_path = ['/recordings/' int2str(X-1)];
-
-                if ch == 1 % only create dataset and write attributes once per recording block
-
-                    if processor_index == 1 % only write to the kwik file for the first processor
+                this_block_ts = int64(info_continuous.ts(in_block));
+                
+                internal_path = ['/recordings/' int2str(block_num - 1)];
+                
+                if block_num > length(blocks_created) || ~blocks_created(block_num)
+                    % only create dataset and write attributes once per recording block                    
+                    blocks_created(block_num) = true;
+                    
+                    if block_num > length(kwik_blocks_written) || ~kwik_blocks_written(block_num)
+                        % only write to the kwik file once per block, over all processors
+                        kwik_blocks_written(block_num) = true;
+                        
                         h5create(kwikfile, [internal_path '/start_sample'], [1 1],...
                             'Datatype', 'int64');
                         h5write(kwikfile, [internal_path '/start_sample'], int64(timestamps(start_sample)));
-
+                        
                         h5create(kwikfile, [internal_path '/sample_rate'], [1 1],...
                             'Datatype', 'int16');
                         h5write(kwikfile, [internal_path '/sample_rate'], int16(info_continuous.header.sampleRate));
                     end
-    
-                    h5create(kwdfile, [internal_path '/data'], ...
-                        [num_channels numel(this_block)], ...
-                        'Datatype', 'int16', ...
-                        'ChunkSize', [1 numel(this_block)]);
                     
-                    h5writeatt(kwdfile, internal_path, 'start_sample', int64(timestamps(start_sample)));
-                    h5writeatt(kwdfile, internal_path, 'sample_rate', int16(info_continuous.header.sampleRate));
-
-                    h5writeatt(kwdfile, internal_path, 'bit_depth', info_continuous.header.bitVolts);
-                    h5create(kwdfile, [internal_path '/application_data/channel_bit_volts'], [1 num_channels], ...
-                        'DataType', 'double');
+                    % keep track of whether this is multi-sample data
+                    firstSampleRate(block_num) = info_continuous.header.sampleRate;
+                    isMultiSample(block_num) = false;
+                    
+                    % datasets
+                    h5create(kwdfile, [internal_path '/application_data/channel_bit_volts'], Inf, ...
+                        'DataType', 'single', 'ChunkSize', 1);
+                    
+                    h5create(kwdfile, [internal_path '/application_data/channel_sample_rates'], Inf, ...
+                        'DataType', 'single', 'ChunkSize', 1);
+                    
+                    h5create(kwdfile, [internal_path '/application_data/timestamps'], ...
+                        [Inf length(this_block_ts)], ...
+                        'Datatype', 'int64', 'ChunkSize', [1 16]);
+                    
+                    h5create(kwdfile, [internal_path '/data'], ...
+                        [Inf numel(this_block)], ...
+                        'Datatype', 'int16', 'ChunkSize', [1 2048]);
+                    
+                    % attributes
+                    h5writeatt(kwdfile, internal_path, 'start_sample', uint32(0));
+                    h5writeatt(kwdfile, internal_path, 'sample_rate', single(firstSampleRate(block_num)));
+                    h5writeatt(kwdfile, internal_path, 'bit_depth', uint32(16));
+                    h5writeatt(kwdfile, internal_path, 'name', sprintf('Open Ephys Recording #%d', block_num - 1));
+                    h5writeatt(kwdfile, internal_path, 'start_time', uint64(this_block_ts(1)));
                 end
                 
+                % get channel index relative to current block
+                bitVoltsInfo = h5info(kwdfile, [internal_path '/application_data/channel_bit_volts']);
+                relative_chan_ind = bitVoltsInfo.Dataspace.Size + 1;
+                
                 h5write(kwdfile, [internal_path '/application_data/channel_bit_volts'], ...
-                    info_continuous.header.bitVolts, [1 ch], [1 1]);
-
-                h5write(kwdfile,[internal_path '/data'], ...
-                    (this_block(1:end))', [ch 1], [1 numel(this_block)]);
-
+                    single(info_continuous.header.bitVolts), relative_chan_ind, 1);
+                
+                chanSampleRate = info_continuous.header.sampleRate;
+                isMultiSample(block_num) = isMultiSample(block_num) | chanSampleRate ~= firstSampleRate(block_num);
+                h5write(kwdfile, [internal_path '/application_data/channel_sample_rates'], ...
+                    single(chanSampleRate), relative_chan_ind, 1);
+                
+                h5write(kwdfile, [internal_path '/application_data/timestamps'], ...
+                    this_block_ts', [relative_chan_ind 1], [1 length(this_block_ts)]);
+                
+                h5write(kwdfile, [internal_path '/data'], ...
+                    (this_block(1:end))', [relative_chan_ind 1], [1 numel(this_block)]);
+                
             end
-
+            
         end
-
-    end
-end
-
-%%
-
-% 3. create the KWX file
-
-kwxfile = [get_full_path(output_directory) filesep ...
-    'spikes.kwx'];
-
-info.kwxfile = kwxfile;
-
-if numel(dir(kwxfile))
-    delete(kwxfile)
-end
-
-for X = 1:size(info.electrodes,1)
-    
-    filename_string = info.electrodes{X, 1};
-    channels = info.electrodes{X, 2};
-    
-    internal_path = ['/channel_groups/' int2str(X-1)];
-    
-    for ch = 1:length(channels)
-       
-        h5create(kwikfile, [internal_path '/' int2str(ch-1) '/kwd_index'], [1 1], 'Datatype', 'int16');
-        h5write(kwikfile, [internal_path '/' int2str(ch-1) '/kwd_index'], int16(channels(ch)));
+        
+        for block_num = find(blocks_created)
+            internal_path = ['/recordings/' int2str(block_num - 1)];
+            h5writeatt(kwdfile, [internal_path '/application_data'], 'is_multiSampleRate_data', uint8(isMultiSample(block_num)));
+        end
     end
     
-    h5writeatt(kwikfile, internal_path, 'name', filename_string);
+    %%
     
-    filename_string(filename_string == ' ') = [ ];
+    % 3. create the KWX file
     
-    filename_in = [input_directory filesep ...
-        filename_string '.spikes'];
+    kwxfile = [get_full_path(output_directory) filesep ...
+        experiment_prefix '.kwx'];
     
-    [data, timestamps, info_spikes] = load_open_ephys_data(filename_in);
+    info(kE).kwxfile = kwxfile;
     
-     h5create(kwxfile, [internal_path '/waveforms_filtered'], ...
-                 size(data), ...
-                 'Datatype', 'int16', ...
-                 'ChunkSize',[1 size(data,2) size(data,3)]);
-             
-     rescaled_waveforms = data.*repmat(reshape(info_spikes.gain, ...
-                      [size(info_spikes.gain,1) 1 size(info_spikes.gain,2)]), ...
-                      [1 size(data,2) 1])./1000;
+    if numel(dir(kwxfile))
+        delete(kwxfile)
+    end
     
-     h5write(kwxfile,[internal_path '/waveforms_filtered'], ...
-             int16(rescaled_waveforms));
-    
+    for block_num = 1:size(info(kE).electrodes,1)
+        
+        filename_string = info(kE).electrodes{block_num, 1};
+        channels = info(kE).electrodes{block_num, 2};
+        
+        internal_path = ['/channel_groups/' int2str(block_num-1)];
+        
+        for ch = 1:length(channels)
+            
+            h5create(kwikfile, [internal_path '/' int2str(ch-1) '/kwd_index'], [1 1], 'Datatype', 'int16');
+            h5write(kwikfile, [internal_path '/' int2str(ch-1) '/kwd_index'], int16(channels(ch)));
+        end
+        
+        h5writeatt(kwikfile, internal_path, 'name', filename_string);
+        
+        filename_string(filename_string == ' ') = [ ];
+        
+        filename_in = [input_directory filesep ...
+            filename_string '.spikes'];
+        
+        [data, ~, info_spikes] = load_open_ephys_data(filename_in);
+        
+        h5create(kwxfile, [internal_path '/waveforms_filtered'], ...
+            size(data), ...
+            'Datatype', 'int16', ...
+            'ChunkSize',[1 size(data,2) size(data,3)]);
+        
+        rescaled_waveforms = data.*repmat(reshape(info_spikes.gain, ...
+            [size(info_spikes.gain,1) 1 size(info_spikes.gain,2)]), ...
+            [1 size(data,2) 1])./1000;
+        
+        h5write(kwxfile,[internal_path '/waveforms_filtered'], ...
+            int16(rescaled_waveforms));
+        
+    end
+
 end
 

--- a/convert_open_ephys_to_kwik.m
+++ b/convert_open_ephys_to_kwik.m
@@ -79,6 +79,26 @@ for kE = 1:length(info)
         num_blocks = length(recorded_channels_per_block);
 
         recorded_channels = unique([recorded_channels_per_block{:}]);
+
+        % check for missing files and filter
+        files_exist = cellfun(@(name) exist(name, 'file'), recorded_channels) == 2;
+        if ~all(files_exist)
+            warning('Some data files for %s (node %d) are missing.', ...
+                info(kE).processors{processor, 2}, info(kE).processors{processor, 1});
+
+            % remove each missing file from per-recording lists
+            for missing_file_ind = find(~files_exist(:)')
+                missing_file = recorded_channels{missing_file_ind};
+                for block = 1:num_blocks
+                    files = recorded_channels_per_block{block};
+                    recorded_channels_per_block{block} = files(~strcmp(missing_file, files));
+                end
+            end
+
+            % remove missing files from merged list
+            recorded_channels = recorded_channels(files_exist);
+        end
+
         num_channels = length(recorded_channels);
         
         if num_channels == 0

--- a/get_session_info.m
+++ b/get_session_info.m
@@ -3,124 +3,159 @@ function info = get_session_info(directory)
 % STEP 1: GET FULL PATH FOR DIRECTORY
 
 directory = get_full_path(directory);
+directory_contents = dir(directory);
+
 
 %%
 
-% STEP 2: PARSE THE 'SETTINGS.XML' FILE
+% STEP 2: FIND NUMBER OF RECORDING SESSIONS
 
-directory_contents = dir(directory);
+settingsPattern = '^settings(_\d+)?\.xml$';
+isSettingsFile = regexp({directory_contents.name}, settingsPattern, 'once');
+numSessions = length(cell2mat(isSettingsFile));
 
-DOMnode = xmlread([directory filesep 'settings.xml']);
-xRoot =DOMnode.getDocumentElement;
-
-processors = cell(0);
-electrodes = cell(0);
-
-% LOOP THROUGH TOP-LEVEL NODES
-for i = 1:xRoot.getChildNodes.getLength-1
-   
-    if strcmp(xRoot.item(i).getNodeName, 'SIGNALCHAIN')
+for s = numSessions:-1:1 % iterate backwards to preallocate
+    
+    if s == 1
+        sessStr = '';
+    else
+        sessStr = ['_', num2str(s)];
+    end
+    
+    %%
+    
+    % STEP 3: PARSE THE 'SETTINGS.XML' FILE   
+    
+    settingsFilename = ['settings' sessStr '.xml'];
+    DOMnode = xmlread([directory filesep settingsFilename]);
+    xRoot = DOMnode.getDocumentElement;
+    
+    processors = cell(0);
+    electrodes = cell(0);
+    
+    % LOOP THROUGH TOP-LEVEL NODES
+    for i = 1:xRoot.getChildNodes.getLength-1
         
-        xSignalChain = xRoot.item(i);
-        
-        processorIndex = 0;
-        
-        % LOOP THROUGH PROCESSOR NODES
-        for j = 1:xSignalChain.getChildNodes.getLength-1
+        if strcmp(xRoot.item(i).getNodeName, 'SIGNALCHAIN')
             
-            if strcmp(xSignalChain.item(j).getNodeName, 'PROCESSOR')
+            xSignalChain = xRoot.item(i);
+            
+            processorIndex = 0;
+            
+            % LOOP THROUGH PROCESSOR NODES
+            for j = 1:xSignalChain.getChildNodes.getLength-1
                 
-                processorIndex = processorIndex + 1;
-                
-                xProcessor = xSignalChain.item(j);
-               
-                nodeId = str2double(xProcessor.getAttributes.getNamedItem('NodeId').getValue);
-                processorName = char(xProcessor.getAttributes.getNamedItem('name').getValue);
-                
-                processors{processorIndex,1} = nodeId;
-                processors{processorIndex,2} = processorName;
-                processors{processorIndex,3} = []; % empty cell for channels
-
-                if strcmp(processorName, 'Filters/Spike Detector')
-                   
-                    electrodeIndex = 0;
+                if strcmp(xSignalChain.item(j).getNodeName, 'PROCESSOR')
                     
-                     % LOOP THROUGH ELECTRODE NODES IN SPIKE DETECTOR
-                    for k = 1:xProcessor.getChildNodes.getLength-1
+                    processorIndex = processorIndex + 1;
+                    
+                    xProcessor = xSignalChain.item(j);
+                    
+                    nodeId = str2double(xProcessor.getAttributes.getNamedItem('NodeId').getValue);
+                    processorName = char(xProcessor.getAttributes.getNamedItem('name').getValue);
+                    
+                    processors{processorIndex,1} = nodeId;
+                    processors{processorIndex,2} = processorName;
+                    processors{processorIndex,3} = {}; % to contain recording filenames
+                    
+                    if strcmp(processorName, 'Filters/Spike Detector')
                         
-                        if strcmp(xProcessor.item(k).getNodeName, 'ELECTRODE')
+                        electrodeIndex = 0;
+                        
+                        % LOOP THROUGH ELECTRODE NODES IN SPIKE DETECTOR
+                        for k = 1:xProcessor.getChildNodes.getLength-1
                             
-                           electrodeIndex = electrodeIndex + 1;
-                            
-                           xElectrode = xProcessor.item(k);
-                           
-                           electrodeName = char(xElectrode.getAttributes.getNamedItem('name').getValue);
-                           numChannels = str2double(xElectrode.getAttributes.getNamedItem('numChannels').getValue);
-                           channels = zeros(1, numChannels);
-
-                           channelIndex = 0;
-                           
-                           % LOOP THROUGH CHANNEL NODES FOR ELECTRODE
-                           for m = 1:xElectrode.getChildNodes.getLength-1
-                               
-                              if strcmp(xElectrode.item(m).getNodeName, 'SUBCHANNEL')
-                                  
-                                  channelIndex = channelIndex + 1;
-
-                                  xChannel = xElectrode.item(m);
-                                  
-                                  ch = str2double(xChannel.getAttributes.getNamedItem('ch').getValue);
-                                  
-                                  channels(channelIndex) = ch;
-                                  
-                              end
-                               
-                           end
-                           
-                           electrodes{electrodeIndex,1} = electrodeName;
-                           electrodes{electrodeIndex,2} = channels;
-                            
-                        end                
+                            if strcmp(xProcessor.item(k).getNodeName, 'ELECTRODE')
+                                
+                                electrodeIndex = electrodeIndex + 1;
+                                
+                                xElectrode = xProcessor.item(k);
+                                
+                                electrodeName = char(xElectrode.getAttributes.getNamedItem('name').getValue);
+                                numChannels = str2double(xElectrode.getAttributes.getNamedItem('numChannels').getValue);
+                                channels = zeros(1, numChannels);
+                                
+                                channelIndex = 0;
+                                
+                                % LOOP THROUGH CHANNEL NODES FOR ELECTRODE
+                                for m = 1:xElectrode.getChildNodes.getLength-1
+                                    
+                                    if strcmp(xElectrode.item(m).getNodeName, 'SUBCHANNEL')
+                                        
+                                        channelIndex = channelIndex + 1;
+                                        
+                                        xChannel = xElectrode.item(m);
+                                        
+                                        ch = str2double(xChannel.getAttributes.getNamedItem('ch').getValue);
+                                        
+                                        channels(channelIndex) = ch;
+                                        
+                                    end
+                                    
+                                end
+                                
+                                electrodes{electrodeIndex,1} = electrodeName;
+                                electrodes{electrodeIndex,2} = channels;
+                                
+                            end
+                        end
                     end
                 end
             end
         end
     end
-end
 
-%%
-
-% STEP 3: FIND THE AVAILABLE FILES
-
-for filenum = 1:length(directory_contents)
+    %%
     
-   if numel(strfind(directory_contents(filenum).name, '.continuous')) > 0
-      
-       fname = directory_contents(filenum).name;
-       
-       underscore = strfind(fname, '_');
-       chstr = strfind(fname, 'CH');
-       dot = strfind(fname, '.');
-       
-       nodeId = str2num(fname(1:underscore-1));
-       chNum = str2num(fname(chstr+2:dot-1));
-
-       for n = 1:size(processors,1)
-           if nodeId == processors{n,1}
-               processors{n,3} = [processors{n,3} chNum];
-           end
-       end
-   end
-end
-
-for n = 1:size(processors,1)
-   
-    processors{n,3} = sort(processors{n,3});
+    % STEP 4: PARSE CONTINUOUS_DATA.OPENEPHYS TO GET CONTINUOUS FILENAMES
     
-end
+    DOMnode = xmlread([directory filesep 'Continuous_Data' sessStr '.openephys']);
+    xRoot = DOMnode.getDocumentElement;
+    
+    % loop over recordings
+    for kR = 1:xRoot.getChildNodes.getLength - 1
+        
+        if ~strcmp(xRoot.item(kR).getNodeName, 'RECORDING')
+            continue;
+        end
+        
+        xRecording = xRoot.item(kR);        
+        
+        % loop through processors
+        for kP = 1:xRecording.getChildNodes.getLength - 1
+            if ~strcmp(xRecording.item(kP).getNodeName, 'PROCESSOR')
+                continue;
+            end
 
-info.electrodes = electrodes;
-info.processors = processors;
-info.events_file = 'all_channels.events';
-info.messages_file = 'messages.events';
+            xProcessor = xRecording.item(kP);
+            nodeId = str2double(xProcessor.getAttributes.getNamedItem('id').getValue);
+            procInd = find([processors{:, 1}] == nodeId, 1);
+            if isempty(procInd)
+                warning('Recorded processor number %d not found in %s', nodeId, settingsFilename);
+                procInd = size(processors, 1) + 1;
+                processors{procInd, 1} = nodeId;
+                processors{procInd, 2} = 'Unknown Processor';
+                processors{procInd, 3} = {};
+            end
+            
+            % loop through channels
+            for kC = 1:xProcessor.getChildNodes.getLength - 1
+                if ~strcmp(xProcessor.item(kC).getNodeName, 'CHANNEL')
+                    continue;
+                end
+                
+                xChannel = xProcessor.item(kC);
+                filename = char(xChannel.getAttributes.getNamedItem('filename').getValue);
+                if ~any(strcmp(filename, processors{procInd, 3}))                
+                    processors{procInd, 3}{end+1} = filename;
+                end
+            end
+        end
+    end
+    
+    info(s).electrodes = electrodes;
+    info(s).processors = processors;
+    info(s).events_file = ['all_channels' sessStr '.events'];
+    info(s).messages_file = ['messages' sessStr '.events'];
+end
 end


### PR DESCRIPTION
I made a bunch of changes to convert_open_ephys_to_kwik and get_session_info in order to convert more of the data from a given directory and make the output consistent with the format of recordings done directly in KWIK.

Changes include; 

* Converts multiple "experiments" (recordings with stopping/starting acquisition in between) to their equivalent in KWIK
* AUX and ADC channels are included, since get_session_info now returns cells of all continuous filenames in the "processors" field rather than channel indices. However, due to limitations of the KWD format, they're not labeled as such when loaded in the file viewer (all channels say "data").
* Handles when the recorded channels change from one recording block to the next correctly
* KWD file datasets and attributes have the right datatypes
* The bit_depth attribute now contains 16 rather than the bitVolts value, since that's what the KWIK record engine does. That's inconsistent with how the KWIK file source module interprets that field, so I'm still unsure about what it's supposed to be, but it doesn't have any effect anyway since each channel's individual bitVolts value is now set in channel_bit_volts, which overrides bit_depth.

Not included: any changes to the content of KWIK or KWX files.

I hope this helps make the Open Ephys format more usable!