### PR TITLE
Make RECORD_SIZE accurate in load_open_ephys_data.m

### DIFF
--- a/load_open_ephys_data.m
+++ b/load_open_ephys_data.m
@@ -59,7 +59,6 @@ filesize = getfilesize(fid);
 % constants
 NUM_HEADER_BYTES = 1024;
 SAMPLES_PER_RECORD = 1024;
-RECORD_SIZE = 8 + 16 + SAMPLES_PER_RECORD*2 + 10; % size of each continuous record in bytes
 RECORD_MARKER = [0 1 2 3 4 5 6 7 8 255]';
 RECORD_MARKER_V0 = [0 0 0 0 0 0 0 0 0 255]';
 
@@ -166,7 +165,12 @@ elseif strcmp(filetype, 'continuous')
     
     current_sample = 0;
     
-    while ftell(fid) + RECORD_SIZE < filesize % at least one record remains
+    RECORD_SIZE = 10 + SAMPLES_PER_RECORD*2 + 10; % size of each continuous record in bytes
+    if version >= 0.2
+        RECORD_SIZE = RECORD_SIZE + 2; % include recNum
+    end
+    
+    while ftell(fid) + RECORD_SIZE <= filesize % at least one record remains
         
         go_back_to_start_of_loop = 0;
         


### PR DESCRIPTION
This changes RECORD_SIZE to actually reflect the size of each continuous record, since previously the size of the nsamples field was incorrect and recNum wasn't accounted for. Also, the loop should continue while the result of `ftell` (== the number of bytes read so far) + the number of bytes to read next is <= the file size. 

The effect is to include the last (potentially nonfull) record, which was previously excluded, yielding the same behavior as `load_open_ephys_data_faster`.