### PR TITLE
Use correct # of channels for binary format memory-mapped file in Matlab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "npy-matlab"]
 	path = npy-matlab
-	url = git@github.com:kwikteam/npy-matlab.git
+	url = https://github.com/kwikteam/npy-matlab

--- a/load_open_ephys_binary.m
+++ b/load_open_ephys_binary.m
@@ -89,8 +89,8 @@ switch type
         contFile=fullfile(folder,'continuous.dat');
         if (continuousmap)
             file=dir(contFile);
-            samples=file.bytes/2/header.num_channels
-            D.Data=memmapfile(contFile,'Format',{'int16' [16 samples] 'mapped'})
+            samples=file.bytes/2/header.num_channels;
+            D.Data=memmapfile(contFile,'Format',{'int16' [header.num_channels samples] 'mapped'});
         else
             file=fopen(contFile);
             D.Data=fread(file,[header.num_channels Inf],'int16');
@@ -108,7 +108,7 @@ switch type
         group=char(f.getName());
         if (strncmp(group,'TEXT',4))
             %D.Data = readNPY(fullfile(folder,'text.npy'));
-            display('WARNING: TEXT files not supported by npy library');
+            warning('TEXT files not supported by npy library');
         elseif (strncmp(group,'TTL',3))
             D.Data = readNPY(fullfile(folder,'channel_states.npy'));
             wordfile = fullfile(folder,'full_words.npy');


### PR DESCRIPTION
I noticed that the number of channels for loading binary data as a memory-mapped file in MATLAB is fixed at 16, which I assume is a bug (confirmed that it fails to load correctly if the number of channels is not 16). Changed it to use the number of channels from the header.

This also includes a change to use HTTPS for the submodule url, since the SSH url wasn't working for me (without a token, I guess). I think HTTPS is better than SSH for remotes in general, but I can get rid of that change if desired.