### PR TITLE
Memmapfile for matlab

### DIFF
--- a/load_open_ephys_data.m
+++ b/load_open_ephys_data.m
@@ -277,8 +277,6 @@ elseif strcmp(filetype, 'continuous')
         end
     
     elseif ~isempty(range_pts)
-        
-        %TODO
          
          if (version >= 0.1)
              if version >= 0.2
@@ -288,7 +286,7 @@ elseif strcmp(filetype, 'continuous')
                      'uint16',1,'recNum';...
                      'int16',[SAMPLES_PER_RECORD, 1],'block';...
                      'uint8',[1, 10],'marker'},...
-                     'Offset',1024,'Repeat',Inf);
+                     'Offset',NUM_HEADER_BYTES,'Repeat',Inf);
                  
              else
                  
@@ -297,7 +295,7 @@ elseif strcmp(filetype, 'continuous')
                      'uint16',1,'nsamples';...
                      'int16',[SAMPLES_PER_RECORD, 1],'block';...
                      'uint8',[1, 10],'marker'},...
-                     'Offset',1024,'Repeat',Inf); %TODO not tested
+                     'Offset',NUM_HEADER_BYTES,'Repeat',Inf); %TODO not tested
                  
              end
          else
@@ -306,10 +304,10 @@ elseif strcmp(filetype, 'continuous')
                  'int16',1,'nsamples';...
                  'int16',[SAMPLES_PER_RECORD, 1],'block';...
                  'uint8',[1, 10],'marker'},...
-                 'Offset',1024,'Repeat',Inf); %TODO not tested
+                 'Offset',NUM_HEADER_BYTES,'Repeat',Inf); %TODO not tested
          end
 
-        tf = false(length(m.Data)*1024,1);
+        tf = false(length(m.Data)*SAMPLES_PER_RECORD,1);
         tf(range_pts) = true;
         
         Cblk = cell(length(m.Data),1);
@@ -327,7 +325,7 @@ elseif strcmp(filetype, 'continuous')
             
             if any(tf(SAMPLES_PER_RECORD*(i-1)+1:SAMPLES_PER_RECORD*i))
                                 
-                Cblk{i} = m.Data(i).block(tf(1024*(i-1)+1:SAMPLES_PER_RECORD*i));
+                Cblk{i} = m.Data(i).block(tf(SAMPLES_PER_RECORD*(i-1)+1:SAMPLES_PER_RECORD*i));
                 Cts{i} = double(m.Data(i).timestamp);
                 Cns{i} = double(m.Data(i).nsamples);
                 
@@ -369,9 +367,9 @@ elseif strcmp(filetype, 'continuous')
             ns = info.nsamples(k);
 
             if version >= 0.2
-                offset = 1024 + RECORD_SIZE * (k-1) + 12;           
+                offset = NUM_HEADER_BYTES + RECORD_SIZE * (k-1) + 12;           
             else
-                offset = 1024 + RECORD_SIZE * (k-1) + 10;            
+                offset = NUM_HEADER_BYTES + RECORD_SIZE * (k-1) + 10;            
             end
             
             status = fseek(fid,offset,'bof');

--- a/load_open_ephys_data.m
+++ b/load_open_ephys_data.m
@@ -20,6 +20,12 @@ function [data, timestamps, info] = load_open_ephys_data(filename,varargin)
 %
 %     info: structure with header and other information
 %
+%   Optional Parameter/Value Pairs
+%
+%  'Indices'   row vector of ever increasing positive integers | []
+%              The vector represents the indices for datapoints, allowing
+%              partial reading of the file using memmapfile. If empty, all
+%              the data points will be returned.
 %
 %
 %   DISCLAIMER:

--- a/load_open_ephys_data_faster.m
+++ b/load_open_ephys_data_faster.m
@@ -2,16 +2,20 @@ function [data, timestamps, info] = load_open_ephys_data_faster(filename, vararg
 %
 % [data, timestamps, info] = load_open_ephys_data(filename, [outputFormat])
 %
-%   Loads continuous, event, or spike data files into Matlab.
+%   Loads continuous, event, or spike data files into MATLAB.
 %
 %   Inputs:
 %
 %     filename: path to file
-%     outputFormat: (optional) If omitted, continuous data is output in double format and is scaled to reflect microvolts. 
-%                   If this argument is 'unscaledInt16' and the file contains continuous data, the output data will be in
-%                   int16 format and will not be scaled; this data must be manually converted to a floating-point format
-%                   and multiplied by info.header.bitVolts to obtain microvolt values. This feature is intended to save memory
-%                   for operations involving large amounts of data.
+%     outputFormat: (optional) If omitted, continuous data is output in 
+%                   double format and is scaled to reflect microvolts. If
+%                   this argument is 'unscaledInt16' and the file contains
+%                   continuous data, the output data will be in int16
+%                   format and will not be scaled; this data must be
+%                   manually converted to a floating-point format and
+%                   multiplied by info.header.bitVolts to obtain microvolt
+%                   values. This feature is intended to save memory for
+%                   operations involving large amounts of data.
 %
 %
 %   Outputs:


### PR DESCRIPTION
# What is this PR about?

I modified `load_open_ephys_data.m` to support partial loading of CONTINUOUS data using datapoint indices using `memmapfile`. EVENT or SPIKE data are not supported. 

Partial loading can be particularly useful when the data is very long (the file is big).

# How to validate the change?

You'll need an Open Ephys `*.continuous` file.

## Whole data

```matlab

% filname should be a valid file path to a '*.continuos' file

[A.data, A.timestamps, A.info] = load_open_ephys_data(filename);

[B.data, B.timestamps, B.info] = load_open_ephys_data(filename,'Indices',[]);

assert(isequal(A,B)) % B should be identical to A

```

## Partial loading

```matlab

ind = [300:3300,50000:60000]; % non-consecutive, two parts

[C.data, C.timestamps, C.info] = load_open_ephys_data(filename,'Indices',ind);

assert(isequal(A.data(ind),C.data))

assert(isequal(A.timestamps(ind),C.timestamps))

assert(isequal(A.info.header,C.info.header))

assert(isequal(A.info.ts([1:4,49:59]),C.info.ts))

assert(isequal(A.info.nsamples([1:4,49:59]),C.info.nsamples))

assert(isequal(A.info.recNum([1:4,49:59]),C.info.recNum))

```

## Near end of file

```matlab



L = length(A.data)

[D.data, D.timestamps, D.info] = load_open_ephys_data(filename,'Indices',L-1023:L);

assert(isequal(A.data(L-1023:L),D.data))

assert(isequal(A.timestamps(L-1023:L),D.timestamps))

assert(isequal(A.info.header,D.info.header))

assert(isequal(A.info.ts(end),D.info.ts))

assert(isequal(A.info.nsamples(end),D.info.nsamples))

assert(isequal(A.info.recNum(end),D.info.recNum))
```

# Issues

- EVENT or SPIKE data are not supported for partial loading
- Version < 0.2 has not been tested
- Corrupted file check code was copied underneath partial loading, but not tested. Not sure if it works.


