### PR TITLE
Changed fprintf warning message to Matlab warning message.

### DIFF
--- a/load_open_ephys_binary.m
+++ b/load_open_ephys_binary.m
@@ -124,10 +124,14 @@ if (isfile(metadatafile))
     try
     D.MetaData = readNPY(metadatafile);
     catch EX
-        fprintf('WARNING: cannot read metadata file.\nData structure might not be supported.\n\nError message: %s\nTrace:\n',EX.message);
+        thismsg = sprintf( 'Cannot read metadata file.\nData structure might not be supported.' );
+        thismsg = [ thismsg sprintf( '\n\nError message: %s', EX.message ) ];
+        thismsg = [ thismsg sprintf( '\n\nTrace:' ) ];
         for i=1:length(EX.stack)
-            fprintf('File: %s Function: %s Line: %d\n',EX.stack(i).file,EX.stack(i).name,EX.stack(i).line);
+            thismsg = [ thismsg sprintf( '\nFile: %s Function: %s Line: %d', ...
+              EX.stack(i).file, EX.stack(i).name, EX.stack(i).line ) ];
         end
+        warning(thismsg);
     end
 end
 end


### PR DESCRIPTION
Changed fprintf warning messages in try/catch block to a Matlab warning, so that I can disable display if desired.
(For some reason I'm getting warnings loading files that Open Ephys generated; I'll submit that as a separate issue.)